### PR TITLE
chore: update to 1.21.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.8-SNAPSHOT'
+	id 'fabric-loom' version '1.10-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.parallel=true
 
 # Fabric Properties
 ### Update Here ###
-minecraft_version=1.21.3
-yarn_mappings=1.21.3+build.2
-loader_version=0.16.9
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
+loader_version=0.16.12
 
 # Fabric API
-fabric_version=0.107.0+1.21.3
+fabric_version=0.121.0+1.21.5
 ### Update Here ###
 
 # Mod Properties
@@ -19,7 +19,7 @@ archives_base_name = voicechat-broadcast-fabric
 
 # Dependencies
 voicechat_api_version=2.5.0
-voicechat_version=1.21.3-2.5.25
+voicechat_version=1.21.5-2.5.30
 luckperms_api_version=5.4
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Gradle version: `8.10 >> 8.12`
Fabric Loom version: `1.8-SNAPSHOT >> 1.10-SNAPSHOT`
Fabric Yarn version: `1.21.3+build.2 >> 1.21.5+build.1`
Fabric Loader version: `0.16.9 >> 0.16.12`
Fabric API version: `0.107.0+1.21.3 >> 0.121.0+1.21.5`
Voicechat version: `1.21.3-2.5.25 >> 1.21.5-2.5.30`
Minecraft version: `1.21.3 >> 1.21.5`